### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/OptimalBeauty/3683a712-7dfe-4143-880c-cf7bf81da9de/b4dd5318-37d8-425e-8d99-2d578ac17984/_apis/work/boardbadge/7edb6299-de63-4a81-b3be-67bb39ffba12)](https://dev.azure.com/OptimalBeauty/3683a712-7dfe-4143-880c-cf7bf81da9de/_boards/board/t/b4dd5318-37d8-425e-8d99-2d578ac17984/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#28](https://dev.azure.com/OptimalBeauty/3683a712-7dfe-4143-880c-cf7bf81da9de/_workitems/edit/28). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.